### PR TITLE
Distinguish SVG attributes that do not overlap with HTML attributes

### DIFF
--- a/scalatags/shared/src/main/scala/scalatags/generic/Bundle.scala
+++ b/scalatags/shared/src/main/scala/scalatags/generic/Bundle.scala
@@ -75,7 +75,7 @@ trait Bundle[Builder, Output <: FragT, FragT] extends Aliases[Builder, Output, F
   val svgTags: SvgTags
 
   /**
-   * SVG only attributes
+   * SVG attributes
    */
   val svgAttrs: SvgAttrs
 }
@@ -87,6 +87,7 @@ trait Aliases[Builder, Output <: FragT, FragT]{
   type Styles = generic.Styles[Builder, Output, FragT]
   type Styles2 = generic.Styles2[Builder, Output, FragT]
   type SvgTags = generic.SvgTags[Builder, Output, FragT]
+  type SvgOnlyAttrs = generic.SvgOnlyAttrs[Builder, Output, FragT]
   type SvgAttrs = generic.SvgAttrs[Builder, Output, FragT]
   type Util = generic.Util[Builder, Output, FragT]
   type AttrPair = generic.AttrPair[Builder, FragT]

--- a/scalatags/shared/src/main/scala/scalatags/generic/SvgAttrs.scala
+++ b/scalatags/shared/src/main/scala/scalatags/generic/SvgAttrs.scala
@@ -12,8 +12,10 @@ package generic
 
 import acyclic.file
 
-
-trait SvgAttrs[Builder, Output <: FragT, FragT] extends Util[Builder, Output, FragT] {
+/**
+ * A list of SVG Attributes not also found in Attrs
+ */
+trait SvgOnlyAttrs[Builder, Output <: FragT, FragT] extends Util[Builder, Output, FragT] {
 
   /**
    * This attribute defines the distance from the origin to the top of accent characters,
@@ -189,23 +191,6 @@ trait SvgAttrs[Builder, Output <: FragT, FragT] extends Util[Builder, Output, Fr
    * MDN
    */
   val calcMode = "calcMode".attr
-
-
-  /**
-   * Assigns a class name or set of class names to an element. You may assign the same
-   * class name or names to any number of elements. If you specify multiple class names,
-   * they must be separated by whitespace characters.
-   * The class name of an element has two key roles:
-   * -As a style sheet selector, for use when an author wants to assign style
-   * information to a set of elements.
-   * -For general usage by the browser.
-   * The class can be used to style SVG content using CSS.
-   *
-   * Value 	<list-of-class-names>
-   *
-   * MDN
-   */
-  val `class` = "class".attr
 
 
   /**
@@ -669,8 +654,6 @@ trait SvgAttrs[Builder, Output <: FragT, FragT] extends Util[Builder, Output, Fr
    */
   val imageRendering = "imageRendering".attr
 
-  val id = "id".attr
-
   /**
    *
    *
@@ -872,24 +855,6 @@ trait SvgAttrs[Builder, Output <: FragT, FragT] extends Util[Builder, Output, Fr
    * MDN
    */
   val mask = "mak".attr
-
-
-
-  /**
-   *
-   *
-   * MDN
-   */
-  val max = "max".attr
-
-
-
-  /**
-   *
-   *
-   * MDN
-   */
-  val min = "min".attr
 
 
   /**
@@ -1292,15 +1257,6 @@ trait SvgAttrs[Builder, Output <: FragT, FragT] extends Util[Builder, Output, Fr
    *
    * MDN
    */
-  val style = "style".attr
-
-
-
-  /**
-   *
-   *
-   * MDN
-   */
   val surfaceScale = "surfaceScale".attr
 
 
@@ -1358,14 +1314,6 @@ trait SvgAttrs[Builder, Output <: FragT, FragT] extends Util[Builder, Output, Fr
    * MDN
    */
   val transform = "transform".attr
-
-
-  /*
-   *
-   *
-   * MDN
-   */
-  val `type`= "type".attr
 
 
   /*
@@ -1479,14 +1427,6 @@ trait SvgAttrs[Builder, Output <: FragT, FragT] extends Util[Builder, Output, Fr
   val xmlSpace = "xml:space".attr
 
 
-  /**
-   *
-   *
-   * MDN
-   */
-  val xmlns = "xmlns".attr
-
-
   /*
    *
    *
@@ -1525,4 +1465,67 @@ trait SvgAttrs[Builder, Output <: FragT, FragT] extends Util[Builder, Output, Fr
    * MDN
    */
   val z = "z".attr
+}
+
+/**
+ * All SVG Attributes
+ */
+trait SvgAttrs[Builder, Output <: FragT, FragT] extends SvgOnlyAttrs[Builder, Output, FragT] {
+  /**
+   * Assigns a class name or set of class names to an element. You may assign the same
+   * class name or names to any number of elements. If you specify multiple class names,
+   * they must be separated by whitespace characters.
+   * The class name of an element has two key roles:
+   * -As a style sheet selector, for use when an author wants to assign style
+   * information to a set of elements.
+   * -For general usage by the browser.
+   * The class can be used to style SVG content using CSS.
+   *
+   * Value 	<list-of-class-names>
+   *
+   * MDN
+   */
+  val `class` = "class".attr
+
+  val id = "id".attr
+
+
+  /**
+   *
+   *
+   * MDN
+   */
+  val max = "max".attr
+
+
+  /**
+   *
+   *
+   * MDN
+   */
+  val min = "min".attr
+
+
+  /**
+   *
+   *
+   * MDN
+   */
+  val style = "style".attr
+
+
+  /*
+   *
+   *
+   * MDN
+   */
+  val `type`= "type".attr
+
+
+  /**
+   *
+   *
+   * MDN
+   */
+  val xmlns = "xmlns".attr
 }


### PR DESCRIPTION
This simple change creates a `SVGOnlyAttrs` trait that contains all the attributes that are unique to SVG (in the sense of not being members of the `Attrs` trait). The existing `SVGAttrs` trait is then formed by extending this trait with the few overlapping members.

In this way `SVGAttrs` remains fully backwards-compatible, but we are able to define a single object to hold all attributes, e.g. (where `ST` is `scalatags.Text`):
```scala
object * extends ST.Cap with ST.Attrs with ST.SvgOnlyAttrs
```
with is useful when working with SVG embedded in HTML. (One can alias all tags as <, all styles as ^ and all attributes as *, for example.)