### PR TITLE
Correct name to foreignObject

### DIFF
--- a/scalatags/js/src/main/scala/scalatags/jsdom/SvgTags.scala
+++ b/scalatags/js/src/main/scala/scalatags/jsdom/SvgTags.scala
@@ -49,7 +49,7 @@ trait SvgTags extends generic.SvgTags[dom.Element, dom.Element, dom.Node]{
   val `font-face-name` = "font-face-name".tag[dom.svg.Element]
   val `font-face-src` = "font-face-src".tag[dom.svg.Element]
   val `font-face-uri` = "font-face-uri".tag[dom.svg.Element]
-  val foreignobject = "foreignobject".tag[dom.svg.Element]
+  val foreignObject = "foreignObject".tag[dom.svg.Element]
   val g = "g".tag[dom.svg.G]
   val glyph = "glyph".tag[dom.svg.Element]
   val glyphref = "glyphref".tag[dom.svg.Element]

--- a/scalatags/shared/src/main/scala/scalatags/generic/SvgTags.scala
+++ b/scalatags/shared/src/main/scala/scalatags/generic/SvgTags.scala
@@ -353,7 +353,7 @@ trait SvgTags[Builder, Output <: FragT, FragT] extends Util[Builder, Output, Fra
    *
    * MDN
    */
-  val foreignobject: TypedTag[Builder, Output, FragT]
+  val foreignObject: TypedTag[Builder, Output, FragT]
   /**
    * The g element is a container used to group objects. Transformations applied
    * to the g element are performed on all of its child elements. Attributes

--- a/scalatags/shared/src/main/scala/scalatags/text/SvgTags.scala
+++ b/scalatags/shared/src/main/scala/scalatags/text/SvgTags.scala
@@ -46,7 +46,7 @@ trait SvgTags extends generic.SvgTags[Builder, String, String]{
   val `font-face-name` = "font-face-name".tag
   val `font-face-src` = "font-face-src".tag
   val `font-face-uri` = "font-face-uri".tag
-  val foreignobject = "foreignobject".tag
+  val foreignObject = "foreignObject".tag
   val g = "g".tag
   val glyph = "glyph".tag
   val glyphref = "glyphref".tag


### PR DESCRIPTION
http://www.w3.org/TR/SVG/extend.html#ForeignObjectElement

The "foreignobject" spelling causes this tag not to work in at least
Firefox.