### PR TITLE
Fix for short._ and manual imports.

### DIFF
--- a/scalatags/js/src/main/scala/scalatags/JsDom.scala
+++ b/scalatags/js/src/main/scala/scalatags/JsDom.scala
@@ -41,6 +41,7 @@ object JsDom
   object short
     extends Cap
     with Util
+    with jsdom.Tags
     with DataConverters
     with AbstractShort
     with Aggregate

--- a/scalatags/js/src/main/scala/scalatags/JsDom.scala
+++ b/scalatags/js/src/main/scala/scalatags/JsDom.scala
@@ -40,11 +40,10 @@ object JsDom
 
   object short
     extends Cap
-    with Util
     with jsdom.Tags
     with DataConverters
-    with AbstractShort
     with Aggregate
+    with AbstractShort
     with LowPriorityImplicits{
 
     object * extends Cap with Attrs with Styles

--- a/scalatags/shared/src/main/scala/scalatags/Text.scala
+++ b/scalatags/shared/src/main/scala/scalatags/Text.scala
@@ -36,6 +36,7 @@ object Text
   object short
     extends Cap
     with Util
+    with text.Tags
     with DataConverters
     with Aggregate
     with AbstractShort{

--- a/scalatags/shared/src/main/scala/scalatags/Text.scala
+++ b/scalatags/shared/src/main/scala/scalatags/Text.scala
@@ -35,7 +35,6 @@ object Text
 
   object short
     extends Cap
-    with Util
     with text.Tags
     with DataConverters
     with Aggregate

--- a/scalatags/shared/src/main/scala/scalatags/generic/Bundle.scala
+++ b/scalatags/shared/src/main/scala/scalatags/generic/Bundle.scala
@@ -37,7 +37,7 @@ trait Bundle[Builder, Output <: FragT, FragT] extends Aliases[Builder, Output, F
    * into the local namespace, while leaving Styles and Attributes accessible
    * via the `*` object
    */
-  val short: AbstractShort with Aggregate[Builder, Output, FragT]
+  val short: AbstractShort with Tags with Aggregate[Builder, Output, FragT]
   /**
    * Convenience object for only importing Scalatag's implicits, without importing
    * any of the tags, styles or attributes themselves. This includes conversions to

--- a/scalatags/shared/src/main/scala/scalatags/generic/Bundle.scala
+++ b/scalatags/shared/src/main/scala/scalatags/generic/Bundle.scala
@@ -37,7 +37,7 @@ trait Bundle[Builder, Output <: FragT, FragT] extends Aliases[Builder, Output, F
    * into the local namespace, while leaving Styles and Attributes accessible
    * via the `*` object
    */
-  val short: AbstractShort with Tags with Aggregate[Builder, Output, FragT]
+  val short: AbstractShort with Tags with DataConverters with Aggregate[Builder, Output, FragT]
   /**
    * Convenience object for only importing Scalatag's implicits, without importing
    * any of the tags, styles or attributes themselves. This includes conversions to

--- a/scalatags/shared/src/test/scala/scalatags/generic/ExampleTests.scala
+++ b/scalatags/shared/src/test/scala/scalatags/generic/ExampleTests.scala
@@ -16,16 +16,16 @@ class ExampleTests[Builder, Output <: FragT, FragT](bundle: Bundle[Builder, Outp
       )
     }
     ,
-    /* Commented until we fix the tests for short._
     {
       import bundle.{attrs => attr, styles => css, _}
       import bundle.tags._
+      import bundle.implicits._
       div(
         p(css.color:="red")("Red Text"),
         img(attr.href:="www.imgur.com/picture.jpg")
       )
     }
-    ,*/
+    ,
     """
         <div>
             <p style="color: red;">Red Text</p>

--- a/scalatags/shared/src/test/scala/scalatags/generic/ExampleTests.scala
+++ b/scalatags/shared/src/test/scala/scalatags/generic/ExampleTests.scala
@@ -11,7 +11,7 @@ class ExampleTests[Builder, Output <: FragT, FragT](bundle: Bundle[Builder, Outp
     'manualImports-strCheck({
       import bundle.short._
       div(
-        p(*.color:="red")("Red Text"),
+        p(*.color:="red", *.fontSize:=64.pt)("Big Red Text"),
         img(*.href:="www.imgur.com/picture.jpg")
       )
     }
@@ -20,8 +20,9 @@ class ExampleTests[Builder, Output <: FragT, FragT](bundle: Bundle[Builder, Outp
       import bundle.{attrs => attr, styles => css, _}
       import bundle.tags._
       import bundle.implicits._
+      import scalatags.DataConverters._
       div(
-        p(css.color:="red")("Red Text"),
+        p(css.color:="red", css.fontSize:=64.pt)("Big Red Text"),
         img(attr.href:="www.imgur.com/picture.jpg")
       )
     }

--- a/scalatags/shared/src/test/scala/scalatags/generic/ExampleTests.scala
+++ b/scalatags/shared/src/test/scala/scalatags/generic/ExampleTests.scala
@@ -8,6 +8,31 @@ class ExampleTests[Builder, Output <: FragT, FragT](bundle: Bundle[Builder, Outp
 
 
   val tests = TestSuite{
+    'manualImports-strCheck({
+      import bundle.short._
+      div(
+        p(*.color:="red")("Red Text"),
+        img(*.href:="www.imgur.com/picture.jpg")
+      )
+    }
+    ,
+    /* Commented until we fix the tests for short._
+    {
+      import bundle.{attrs => attr, styles => css, _}
+      import bundle.tags._
+      div(
+        p(css.color:="red")("Red Text"),
+        img(attr.href:="www.imgur.com/picture.jpg")
+      )
+    }
+    ,*/
+    """
+        <div>
+            <p style="color: red;">Red Text</p>
+            <img href="www.imgur.com/picture.jpg" />
+        </div>
+    """
+    )
 
     import bundle.all._
     'splashExample-strCheck(
@@ -454,31 +479,6 @@ class ExampleTests[Builder, Output <: FragT, FragT](bundle: Bundle[Builder, Outp
     """
     )
 
-
-    'manualImports-strCheck({
-      import bundle.short._
-      div(
-        p(*.color:="red")("Red Text"),
-        img(*.href:="www.imgur.com/picture.jpg")
-      )
-    }
-    ,
-    {
-      import bundle.{attrs => attr, styles => css, _}
-      import bundle.tags._
-      div(
-        p(css.color:="red")("Red Text"),
-        img(attr.href:="www.imgur.com/picture.jpg")
-      )
-    }
-    ,
-    """
-        <div>
-            <p style="color: red;">Red Text</p>
-            <img href="www.imgur.com/picture.jpg" />
-        </div>
-    """
-    )
 
     'properEscaping-strCheck({
       val evilInput1 = "\"><script>alert('hello!')</script>"


### PR DESCRIPTION
Addresses issue #86 by modifying `import short._` to work properly in the scope that the docs suggest.
Formerly, the test `'manualImports` was defined after an `import bundle.all._`, allowing errors in the implementation to get through.

Note that the example from the docs that imported:
``` 
import bundle.{attrs => attr, styles => css, _}
import bundle.tags._ 
```
Now requires two additional imports:
```
import bundle.implicits._
import scalatags.DataConverters._ 
```
