### PR TITLE
Code cleanup

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -80,7 +80,18 @@ lazy val example = project.in(file("example"))
   .enablePlugins(ScalaJSPlugin)
   .settings(
     crossScalaVersions := Seq("2.11.4", "2.10.4"),
-    scalaVersion := "2.11.4"
+    scalaVersion := "2.11.4",
+    scalacOptions ++= Seq(
+      "-deprecation", // warning and location for usages of deprecated APIs
+      "-feature", // warning and location for usages of features that should be imported explicitly
+      "-unchecked", // additional warnings where generated code depends on assumptions
+      "-Xlint", // recommended additional warnings
+      "-Xcheckinit", // runtime error when a val is not initialized due to trait hierarchies (instead of NPE somewhere else)
+      "-Ywarn-adapted-args", // Warn if an argument list is modified to match the receiver
+      "-Ywarn-value-discard", // Warn when non-Unit expression results are unused
+      "-Ywarn-inaccessible",
+      "-Ywarn-dead-code"
+    )
   )
 
 lazy val readme = scalatex.ScalatexReadme(

--- a/scalatags/js/src/main/scala/scalatags/JsDom.scala
+++ b/scalatags/js/src/main/scala/scalatags/JsDom.scala
@@ -1,6 +1,7 @@
 package scalatags
 import acyclic.file
 import org.scalajs.dom
+import scala.language.implicitConversions
 import scala.scalajs.js
 
 import org.scalajs.dom.{html, svg, Element}
@@ -72,7 +73,7 @@ object JsDom
     def genericPixelStyle[T](implicit ev: StyleValue[T]): PixelStyleValue[T] = new JsDom.GenericPixelStyle[T](ev)
     def genericPixelStylePx[T](implicit ev: StyleValue[String]): PixelStyleValue[T] = new JsDom.GenericPixelStylePx[T](ev)
 
-    implicit def stringFrag(v: String) = new JsDom.StringFrag(v)
+    implicit def stringFrag(v: String): StringFrag = new JsDom.StringFrag(v)
 
 
     val RawFrag = JsDom.RawFrag
@@ -97,12 +98,12 @@ object JsDom
     protected[this] implicit def stringAttrX = new GenericAttr[String]
     protected[this] implicit def stringStyleX = new GenericStyle[String]
     protected[this] implicit def stringPixelStyleX = new GenericPixelStyle[String](stringStyleX)
-    implicit def UnitFrag(u: Unit) = new JsDom.StringFrag("")
+    implicit def UnitFrag(u: Unit): JsDom.StringFrag = new JsDom.StringFrag("")
     def makeAbstractTypedTag[T <: dom.Element](tag: String, void: Boolean, namespaceConfig: Namespace): TypedTag[T] = {
       TypedTag(tag, Nil, void, namespaceConfig)
     }
 
-    implicit class SeqFrag[A <% Frag](xs: Seq[A]) extends Frag{
+    implicit class SeqFrag[A](xs: Seq[A])(implicit ev: A => Frag) extends Frag{
       def applyTo(t: dom.Element): Unit = xs.foreach(_.applyTo(t))
       def render: dom.Node = {
         val frag = org.scalajs.dom.document.createDocumentFragment()
@@ -176,7 +177,7 @@ trait LowPriorityImplicits{
       t.asInstanceOf[js.Dynamic].updateDynamic(a.name)(v)
     }
   }
-  implicit def bindJsAnyLike[T <% js.Any] = new generic.AttrValue[dom.Element, T]{
+  implicit def bindJsAnyLike[T](implicit ev: T => js.Any) = new generic.AttrValue[dom.Element, T]{
     def apply(t: dom.Element, a: generic.Attr, v: T): Unit = {
       t.asInstanceOf[js.Dynamic].updateDynamic(a.name)(v)
     }

--- a/scalatags/shared/src/main/scala/scalatags/DataTypes.scala
+++ b/scalatags/shared/src/main/scala/scalatags/DataTypes.scala
@@ -11,12 +11,12 @@ object DataConverters extends DataConverters
  * mixed in to other objects as needed.
  */
 trait DataConverters{
-  implicit def Int2CssNumber(x: Int) = new CssNumber(x)
-  implicit def Double2CssNumber(x: Double) = new CssNumber(x)
-  implicit def Float2CssNumber(x: Float) = new CssNumber(x)
-  implicit def Long2CssNumber(x: Long) = new CssNumber(x)
-  implicit def Short2CssNumber(x: Short) = new CssNumber(x)
-  implicit def Byte2CssNumber(x: Byte) = new CssNumber(x)
+  implicit def Int2CssNumber(x: Int): CssNumber[Int] = new CssNumber(x)
+  implicit def Double2CssNumber(x: Double): CssNumber[Double] = new CssNumber(x)
+  implicit def Float2CssNumber(x: Float): CssNumber[Float] = new CssNumber(x)
+  implicit def Long2CssNumber(x: Long): CssNumber[Long] = new CssNumber(x)
+  implicit def Short2CssNumber(x: Short): CssNumber[Short] = new CssNumber(x)
+  implicit def Byte2CssNumber(x: Byte): CssNumber[Byte] = new CssNumber(x)
   /**
    * Extends numbers to provide a bunch of useful methods, allowing you to write
    * CSS-lengths in a nice syntax without resorting to strings.

--- a/scalatags/shared/src/main/scala/scalatags/Text.scala
+++ b/scalatags/shared/src/main/scala/scalatags/Text.scala
@@ -1,8 +1,6 @@
 package scalatags
 import acyclic.file
 import scalatags.generic._
-import scala.collection.SortedMap
-import collection.mutable
 import scala.annotation.unchecked.uncheckedVariance
 import scalatags.stylesheet.{StyleSheetFrag, StyleTree}
 import scalatags.text.Builder

--- a/scalatags/shared/src/main/scala/scalatags/generic/Bundle.scala
+++ b/scalatags/shared/src/main/scala/scalatags/generic/Bundle.scala
@@ -149,12 +149,12 @@ trait Aggregate[Builder, Output <: FragT, FragT] extends Aliases[Builder, Output
   implicit val floatPixelStyle = genericPixelStylePx[Float]
   implicit val doublePixelStyle = genericPixelStylePx[Double]
 
-  implicit def byteFrag(v: Byte) = stringFrag(v.toString)
-  implicit def shortFrag(v: Short) = stringFrag(v.toString)
-  implicit def intFrag(v: Int) = stringFrag(v.toString)
-  implicit def longFrag(v: Long) = stringFrag(v.toString)
-  implicit def floatFrag(v: Float) = stringFrag(v.toString)
-  implicit def doubleFrag(v: Double) = stringFrag(v.toString)
+  implicit def byteFrag(v: Byte): Frag = stringFrag(v.toString)
+  implicit def shortFrag(v: Short): Frag = stringFrag(v.toString)
+  implicit def intFrag(v: Int): Frag = stringFrag(v.toString)
+  implicit def longFrag(v: Long): Frag = stringFrag(v.toString)
+  implicit def floatFrag(v: Float): Frag = stringFrag(v.toString)
+  implicit def doubleFrag(v: Double): Frag = stringFrag(v.toString)
   implicit def stringFrag(v: String): Frag
 
   /**

--- a/scalatags/shared/src/main/scala/scalatags/generic/Core.scala
+++ b/scalatags/shared/src/main/scala/scalatags/generic/Core.scala
@@ -2,8 +2,6 @@ package scalatags
 package generic
 
 import acyclic.file
-import scala.collection.SortedMap
-import scalatags.generic
 import scala.annotation.implicitNotFound
 
 

--- a/scalatags/shared/src/main/scala/scalatags/stylesheet/StyleSheet.scala
+++ b/scalatags/shared/src/main/scala/scalatags/stylesheet/StyleSheet.scala
@@ -12,7 +12,7 @@ import scalatags.ScalaVersionStubs.Context
  * when you do to prevent accidental cascading.
  */
 trait CascadingStyleSheet extends StyleSheet with StyleSheetTags{
-  implicit def clsSelector(c: Cls) = new Selector(Seq("." + c.name))
+  implicit def clsSelector(c: Cls): Selector = new Selector(Seq("." + c.name))
 }
 
 /**
@@ -23,7 +23,7 @@ trait CascadingStyleSheet extends StyleSheet with StyleSheetTags{
 trait StyleSheet{
   /**
    * The name of this CSS stylesheet. Defaults to the name of the trait,
-   * but you can overrid
+   * but you can override
    */
   def customSheetName: Option[String] = None
 


### PR DESCRIPTION
This is a pull request that implements some code cleanup (as well as removing depreciations, which will matter for Scala 2.12)

- Syntax cleanup (specified return parameters for implicit def)
- Depreciation (changed view bounds to context bounds)
- Removed unused imports
- Added imports for advanced language features
- Added extra warning flags to Scalac