### PR TITLE
Fix js.map file

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -52,6 +52,7 @@ lazy val scalatags = crossProject
         </developers>
   )
   .jvmSettings()
+  .jsConfigure(_.enablePlugins(ScalaJsMap))
   .jsSettings(
     scalaJSUseRhino in Global := false,
     libraryDependencies ++= Seq(
@@ -59,12 +60,7 @@ lazy val scalatags = crossProject
     ),
     resolvers += Resolver.sonatypeRepo("releases"),
     scalaJSStage in Test := FullOptStage,
-    requiresDOM := true,
-    scalacOptions ++= (if (isSnapshot.value) Seq.empty else Seq({
-      val a = baseDirectory.value.toURI.toString.replaceFirst("[^/]+/?$", "")
-      val g = "https://raw.githubusercontent.com/lihaoyi/scalatags"
-      s"-P:scalajs:mapSourceURI:$a->$g/v${version.value}/"
-    }))
+    requiresDOM := true
   )
 
 

--- a/project/build.sbt
+++ b/project/build.sbt
@@ -3,3 +3,5 @@ addSbtPlugin("org.scala-js" % "sbt-scalajs" % "0.6.8")
 addSbtPlugin("com.typesafe.sbt" % "sbt-twirl" % "1.1.1")
 
 addSbtPlugin("com.lihaoyi" % "scalatex-sbt-plugin" % "0.3.5")
+
+addSbtPlugin("com.thoughtworks.sbt-scala-js-map" % "sbt-scala-js-map" % "1.0.1")


### PR DESCRIPTION
I found that the js.map file references https://raw.githubusercontent.com/lihaoyi/scalatags/v0.5.5/js/src/main/scala/scalatags/JsDom.scala , which does not exsist.

A more delicate approach is generating the `mapSourceURI` option from git metadata instead of hard-coding.

This patch use a sbt plugin https://github.com/ThoughtWorksInc/sbt-scala-js-map/ to implement this approach.