### PR TITLE
Data converters in implicits

### DIFF
--- a/scalatags/js/src/main/scala/scalatags/JsDom.scala
+++ b/scalatags/js/src/main/scala/scalatags/JsDom.scala
@@ -27,7 +27,7 @@ object JsDom
   object svgTags extends JsDom.Cap with jsdom.SvgTags
   object svgAttrs extends JsDom.Cap with SvgAttrs
 
-  object implicits extends Aggregate
+  object implicits extends Aggregate with DataConverters
 
   object all
     extends Cap

--- a/scalatags/shared/src/main/scala/scalatags/Text.scala
+++ b/scalatags/shared/src/main/scala/scalatags/Text.scala
@@ -24,7 +24,8 @@ object Text
   object svgTags extends Text.Cap with text.SvgTags
   object svgAttrs extends Text.Cap with SvgAttrs
 
-  object implicits extends Aggregate
+  object implicits extends Aggregate with DataConverters
+
   object all
     extends Cap
     with Attrs

--- a/scalatags/shared/src/main/scala/scalatags/generic/Bundle.scala
+++ b/scalatags/shared/src/main/scala/scalatags/generic/Bundle.scala
@@ -44,7 +44,7 @@ trait Bundle[Builder, Output <: FragT, FragT] extends Aliases[Builder, Output, F
    * [[Modifier]], typeclass instances for treating strings and numbers as attributes
    * or style values, and other things.
    */
-  val implicits: Aggregate[Builder, Output, FragT]
+  val implicits: Aggregate[Builder, Output, FragT] with DataConverters
 
   type AbstractShort = generic.AbstractShort[Builder, Output, FragT]
 

--- a/scalatags/shared/src/test/scala/scalatags/generic/ExampleTests.scala
+++ b/scalatags/shared/src/test/scala/scalatags/generic/ExampleTests.scala
@@ -20,7 +20,6 @@ class ExampleTests[Builder, Output <: FragT, FragT](bundle: Bundle[Builder, Outp
       import bundle.{attrs => attr, styles => css, _}
       import bundle.tags._
       import bundle.implicits._
-      import scalatags.DataConverters._
       div(
         p(css.color:="red", css.fontSize:=64.pt)("Big Red Text"),
         img(attr.href:="www.imgur.com/picture.jpg")


### PR DESCRIPTION
Add Data Converters to the `implicits` import. I don't see why anyone would want to `import implicits._` but not also `import DataConverters._`. This addresses a small part of #119 