### PR TITLE
Performance improvements to rendering

### DIFF
--- a/scalatags/shared/src/main/scala/scalatags/Escaping.scala
+++ b/scalatags/shared/src/main/scala/scalatags/Escaping.scala
@@ -13,11 +13,34 @@ object Escaping {
    */
   def validTag(s: String) = tagRegex.unapplySeq(s).isDefined
 
-  private[this] val attrNameRegex = "^[a-zA-Z_:][-a-zA-Z0-9_:.]*$".r
   /**
-   * Uses a regex to check if something is a valid attribute name.
+   * Check if 's' is a valid attribute name.
    */
-  def validAttrName(s: String) = attrNameRegex.unapplySeq(s).isDefined
+  def validAttrName(s: String): Boolean = {
+    // this is equivalent of the regex but without a huge amount of object creation.
+    // original regex - ^[a-zA-Z_:][-a-zA-Z0-9_:.]*$
+    // n.b. I know its ugly, but its fast
+    val len = s.length
+    if(len == 0)
+      return false
+
+    val sc = s.charAt(0)
+    val startCharValid = (sc >= 'a' && sc <='z') || (sc >= 'A' && sc <='Z') || sc ==':'
+    if(!startCharValid)
+      return false
+
+    var pos = 1
+    while (pos < len) {
+      val c = s.charAt(pos)
+      val valid = (c >= 'a' && c <='z') || (c >= 'A' && c <='Z') || (c >= '0' && c <='9') ||
+        c == '-' || c ==':' || c =='.' || c == '_'
+      if(!valid)
+        return false
+      pos += 1
+    }
+
+    true
+  }
 
   /**
    * Code to escape text HTML nodes. Taken from scala.xml
@@ -29,27 +52,20 @@ object Escaping {
     // dpp (David Pollak) 2010/02/03
     val len = text.length
     var pos = 0
-    var prev = 0
 
-    @inline
-    def handle(snip: String) = {
-      s.append(text.substring(prev, pos))
-      s.append(snip)
-    }
     while (pos < len) {
       text.charAt(pos) match {
-        case '<' => handle("&lt;"); prev = pos + 1
-        case '>' => handle("&gt;"); prev = pos + 1
-        case '&' => handle("&amp;"); prev = pos + 1
-        case '"' => handle("&quot;"); prev = pos + 1
-        case '\n' => handle("\n"); prev = pos + 1
-        case '\r' => handle("\r"); prev = pos + 1
-        case '\t' => handle("\t"); prev = pos + 1
-        case c if c < ' ' => handle(""); prev = pos + 1
-        case _ =>
+        case '<' => s.append("&lt;")
+        case '>' => s.append("&gt;")
+        case '&' => s.append("&amp;")
+        case '"' => s.append("&quot;")
+        case '\n' => s.append('\n')
+        case '\r' => s.append('\r')
+        case '\t' => s.append('\t')
+        case c if c < ' ' =>
+        case c => s.append(c)
       }
       pos += 1
     }
-    handle("")
   }
 }

--- a/scalatags/shared/src/main/scala/scalatags/package.scala
+++ b/scalatags/shared/src/main/scala/scalatags/package.scala
@@ -8,6 +8,17 @@ import language.experimental.macros
  * and documentation.
  */
 package object scalatags {
+
+  case class ChainedAttributeValueSource(head: AttrValueSource, tail: AttrValueSource) extends AttrValueSource {
+    override def appendAttrValue(strb: StringBuilder): Unit = {
+      head.appendAttrValue(strb)
+      tail.appendAttrValue(strb)
+    }
+  }
+  trait AttrValueSource {
+    def appendAttrValue(strb: StringBuilder): Unit
+  }
+
   private[scalatags] def camelCase(dashedString: String) = {
     val first :: rest = dashedString.split("-").toList
 

--- a/scalatags/shared/src/main/scala/scalatags/text/Builder.scala
+++ b/scalatags/shared/src/main/scala/scalatags/text/Builder.scala
@@ -13,9 +13,37 @@ import scala.reflect.ClassTag
  * so even though the stuff isn't private, don't touch it!
  */
 class Builder(var children: Array[Frag] = new Array(4),
-              var attrs: Array[(String, String)] = new Array(4)){
+              var attrs: Array[(String, AttrValueSource)] = new Array(4)){
   final var childIndex = 0
   final var attrIndex = 0
+
+  private[this] def incrementChidren(arr: Array[Frag], index: Int) = {
+    if (index >= arr.length){
+      val newArr = new Array[Frag](arr.length * 2)
+      var i = 0
+      while(i < arr.length){
+        newArr(i) = arr(i)
+        i += 1
+      }
+      newArr
+    }else{
+      null
+    }
+  }
+
+  private[this] def incrementAttr(arr: Array[(String, AttrValueSource)], index: Int) = {
+    if (index >= arr.length){
+      val newArr = new Array[(String, AttrValueSource)](arr.length * 2)
+      var i = 0
+      while(i < arr.length){
+        newArr(i) = arr(i)
+        i += 1
+      }
+      newArr
+    }else{
+      null
+    }
+  }
 
   private[this] def increment[T: ClassTag](arr: Array[T], index: Int) = {
     if (index >= arr.length){
@@ -31,37 +59,51 @@ class Builder(var children: Array[Frag] = new Array(4),
     }
   }
   def addChild(c: Frag) = {
-    val newChildren = increment(children, childIndex)
+    val newChildren = incrementChidren(children, childIndex)
     if (newChildren != null) children = newChildren
     children(childIndex) = c
     childIndex += 1
   }
-  def appendAttr(k: String, v: String) = {
+  def appendAttr(k: String, v: AttrValueSource) = {
 
     attrIndex(k) match{
       case -1 =>
-        val newAttrs = increment(attrs, attrIndex)
+        val newAttrs = incrementAttr(attrs, attrIndex)
         if (newAttrs!= null) attrs = newAttrs
 
         attrs(attrIndex) = k -> v
         attrIndex += 1
       case n =>
         val (oldK, oldV) = attrs(n)
-        attrs(n) = (oldK, oldV + v)
+        attrs(n) = (oldK, ChainedAttributeValueSource(oldV, v))
     }
   }
-  def setAttr(k: String, v: String) = {
+  def setAttr(k: String, v: AttrValueSource) = {
     attrIndex(k) match{
       case -1 =>
-        val newAttrs = increment(attrs, attrIndex)
+        val newAttrs = incrementAttr(attrs, attrIndex)
         if (newAttrs!= null) attrs = newAttrs
         attrs(attrIndex) = k -> v
         attrIndex += 1
       case n =>
         val (oldK, oldV) = attrs(n)
-        attrs(n) = (oldK, v)
+        attrs(n) = (oldK, ChainedAttributeValueSource(oldV, v))
     }
   }
+
+
+  def appendAttrStrings(v: AttrValueSource, sb: StringBuilder): Unit = {
+    v.appendAttrValue(sb)
+  }
+
+  def attrsString(v: AttrValueSource): String = {
+    val sb = new StringBuilder
+    appendAttrStrings(v, sb)
+    sb.toString
+  }
+
+
+
   def attrIndex(k: String): Int = {
     attrs.indexWhere(x => x != null && x._1 == k)
   }


### PR DESCRIPTION
Improve the rendering performance by reducing creating of intermediate data structures (mainly StringBuilders) and other minor tweaks.

Key change is to change the building of attributes from generating the value string immediately during the building phase to returning an ```AttrValueSource``` so that this can be rendered directly to the output string builder.

Also replaced the Regex based ```validAttrName``` with a faster hand-coded solution (its a simply regex) - this version is significantly faster and has no garbage churn.

Escaping.escape has also been rewritten to avoid intermediate String creation and improve performance.

The ```Builder``` increment method creates ClassTag instances on every invocation, replaced with a pair of method that hard-code the array types.
