### PR TITLE
Upgrade scala-js-dom dependency to 0.9.1

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -55,7 +55,7 @@ lazy val scalatags = crossProject
   .jsSettings(
     scalaJSUseRhino in Global := false,
     libraryDependencies ++= Seq(
-      "org.scala-js" %%% "scalajs-dom" % "0.8.2"
+      "org.scala-js" %%% "scalajs-dom" % "0.9.1"
     ),
     resolvers += Resolver.sonatypeRepo("releases"),
     scalaJSStage in Test := FullOptStage,


### PR DESCRIPTION
It is currently on 0.8.2 and other projects are already on the 0.9.x version.

Can't have other dependencies upgraded as scalatags is still on 0.8.x.

#128