### PR TITLE
Include more implicit conversions in implicits

### DIFF
--- a/scalatags/js/src/main/scala/scalatags/JsDom.scala
+++ b/scalatags/js/src/main/scala/scalatags/JsDom.scala
@@ -32,7 +32,7 @@ object JsDom
   object svgTags extends JsDom.Cap with jsdom.SvgTags
   object svgAttrs extends JsDom.Cap with SvgAttrs
 
-  object implicits extends Aggregate with DataConverters
+  object implicits extends Aggregate with DataConverters with Cap with LowPriorityImplicits
 
   object all
     extends Cap


### PR DESCRIPTION
This change makes more implicit conversions available in the `implicits` object.
