### PR TITLE
Fix issue #139

### DIFF
--- a/scalatags/js/src/main/scala/scalatags/JsDom.scala
+++ b/scalatags/js/src/main/scala/scalatags/JsDom.scala
@@ -136,8 +136,13 @@ object JsDom
     def apply(t: dom.Element, a: Attr, v: T): Unit = {
       a.namespace match {
         case None =>
-          if (!a.raw) t.setAttribute(a.name, v.toString)
-          else {
+          if (!a.raw) {
+            a.name match {
+              case "class" if t.getAttribute("class") != null =>
+                t.setAttribute("class", t.getAttribute("class") + " " + v.toString)
+              case _                                          => t.setAttribute(a.name, v.toString)
+            }
+          } else {
 
             // Ugly workaround for https://www.w3.org/Bugs/Public/show_bug.cgi?id=27228
             val tmpElm = dom.document.createElement("p")

--- a/scalatags/shared/src/main/scala/scalatags/text/Builder.scala
+++ b/scalatags/shared/src/main/scala/scalatags/text/Builder.scala
@@ -139,6 +139,7 @@ object Builder{
   case class ChainedAttributeValueSource(head: ValueSource, tail: ValueSource) extends ValueSource {
     override def appendAttrValue(strb: StringBuilder): Unit = {
       head.appendAttrValue(strb)
+      strb.append(" ")
       tail.appendAttrValue(strb)
     }
   }

--- a/scalatags/shared/src/test/scala/scalatags/generic/BasicTests.scala
+++ b/scalatags/shared/src/test/scala/scalatags/generic/BasicTests.scala
@@ -158,6 +158,24 @@ class BasicTests[Builder, Output <: FragT, FragT](omg: Bundle[Builder, Output, F
       * - intercept[java.lang.IllegalArgumentException](div(attr("[(ngModel)]") := "myModel"))
     }
 
+    'classConcatenation- {
+      // strCheck gets rid of spaces -- which is exactly the issue we're testing for.  So don't use it.
+      val html = div(cls := "red", cls := "yellow")("body")
+      assert(html.toString == """<div class="red yellow">body</div>""")
+    }
+
+    'classStyleSheetConcatenation- {
+      object Foo extends stylesheet.StyleSheet {
+        val myCls = cls(color := "red")
+      }
+      // Classes have a leading space on the JVM that isn't present in jsDom.
+      val htmlLeft = div(Foo.myCls, cls := "red")
+      assert(htmlLeft.toString.replaceAll("\" ", "\"") == """<div class="scalatags-generic-BasicTests-Foo-myCls red"></div>""")
+
+      val htmlRight = div(cls := "red", Foo.myCls)
+      assert(htmlRight.toString.replaceAll(" +", " ") == """<div class="red scalatags-generic-BasicTests-Foo-myCls"></div>""")
+    }
+
   }
 }
 


### PR DESCRIPTION
concatenation of classes (e.g.: div(cls := “red”, cls := “yellow”) into <div class=“red yellow”></div>.