### PR TITLE
add top and bottom for vertical-align

### DIFF
--- a/scalatags/shared/src/main/scala/scalatags/generic/Styles.scala
+++ b/scalatags/shared/src/main/scala/scalatags/generic/Styles.scala
@@ -1942,6 +1942,13 @@ trait Styles[Builder, Output <: FragT, FragT] extends StyleMisc[Builder, Output,
      */
     lazy val `text-bottom` = this := "text-bottom"
     /**
+     * Align the top of the element and its descendants with the top of the
+     * entire line.
+     *
+     * MDN
+     */
+    lazy val top = this := "top"
+    /**
      * Aligns the middle of the element with the middle of lowercase letters in
      * the parent.
      *

--- a/scalatags/shared/src/main/scala/scalatags/generic/Styles.scala
+++ b/scalatags/shared/src/main/scala/scalatags/generic/Styles.scala
@@ -1915,6 +1915,13 @@ trait Styles[Builder, Output <: FragT, FragT] extends StyleMisc[Builder, Output,
      */
     lazy val baseline = this := "baseline"
     /**
+     * Align the bottom of the element and its descendants with the bottom of
+     * the entire line.
+     *
+     * MDN
+     */
+    lazy val bottom = this := "bottom"
+    /**
      * Aligns the baseline of the element with the subscript-baseline of its
      * parent.
      *


### PR DESCRIPTION
I did not see a contribution guide in this repository, so please let me know if I'm missing something or you would prefer different styles.

I opened #161 regarding this. Discussion can be there or here.

I am trying to set vertical alignment for non-text items in one of my styles, and while there are both workarounds as well as other ways to do this, I would like to have parity with the CSS standard on this.

These two values are listed on [MDN: vertical-align](https://developer.mozilla.org/en-US/docs/Web/CSS/vertical-align), and in the CSS level 1 and level 2 W3C specs.

```
vertical-align: top;
vertical-align: bottom;
```