### PR TITLE
Radial gradient focus point attributes

### DIFF
--- a/scalatags/shared/src/main/scala/scalatags/generic/SvgAttrs.scala
+++ b/scalatags/shared/src/main/scala/scalatags/generic/SvgAttrs.scala
@@ -639,6 +639,22 @@ trait SvgAttrs[Builder, Output <: FragT, FragT] extends Util[Builder, Output, Fr
 
 
   /**
+    *
+    *
+    * MDN
+    */
+  lazy val fx = attr("fx")
+
+
+  /**
+    *
+    *
+    * MDN
+    */
+  lazy val fy = attr("fy")
+
+  
+  /**
    *
    *
    * MDN


### PR DESCRIPTION
`SvgAttrs` lacks two important attributes for `<radialGradient>` tag namely `fx` and `fy`.

https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/fx
https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/fy