### PR TITLE
Use java.lang.StringBuilder

### DIFF
--- a/scalatags/shared/src/main/scala/scalatags/Escaping.scala
+++ b/scalatags/shared/src/main/scala/scalatags/Escaping.scala
@@ -1,4 +1,6 @@
 package scalatags
+import java.lang.{StringBuilder => jStringBuilder}
+
 import acyclic.file
 /**
  * Utility methods related to validating and escaping XML; used internally but
@@ -45,7 +47,7 @@ object Escaping {
   /**
    * Code to escape text HTML nodes. Taken from scala.xml
    */
-  def escape(text: String, s: StringBuilder) = {
+  def escape(text: String, s: jStringBuilder) = {
     // Implemented per XML spec:
     // http://www.w3.org/International/questions/qa-controls
     // imperative code 3x-4x faster than current implementation
@@ -62,8 +64,7 @@ object Escaping {
         case '\n' => s.append('\n')
         case '\r' => s.append('\r')
         case '\t' => s.append('\t')
-        case c if c < ' ' =>
-        case c => s.append(c)
+        case c => if (c >= ' ') s.append(c)
       }
       pos += 1
     }

--- a/scalatags/shared/src/main/scala/scalatags/Text.scala
+++ b/scalatags/shared/src/main/scala/scalatags/Text.scala
@@ -1,5 +1,6 @@
 package scalatags
 import java.util.Objects
+import java.lang.{StringBuilder => jStringBuilder}
 
 import acyclic.file
 
@@ -67,7 +68,7 @@ object Text
     implicit def ClsModifier(s: stylesheet.Cls): Modifier = new Modifier with text.Builder.ValueSource{
       def applyTo(t: text.Builder) = t.appendAttr("class",this)
 
-      override def appendAttrValue(sb: StringBuilder): Unit = {
+      override def appendAttrValue(sb: jStringBuilder): Unit = {
         Escaping.escape(s.name, sb)
       }
     }
@@ -102,18 +103,18 @@ object Text
   case class StringFrag(v: String) extends text.Frag{
     Objects.requireNonNull(v)
     def render = {
-      val strb = new StringBuilder()
+      val strb = new jStringBuilder()
       writeTo(strb)
       strb.toString()
     }
-    def writeTo(strb: StringBuilder) = Escaping.escape(v, strb)
+    def writeTo(strb: jStringBuilder) = Escaping.escape(v, strb)
   }
   object StringFrag extends Companion[StringFrag]
   object RawFrag extends Companion[RawFrag]
   case class RawFrag(v: String) extends text.Frag {
     Objects.requireNonNull(v)
     def render = v
-    def writeTo(strb: StringBuilder) = strb ++= v
+    def writeTo(strb: jStringBuilder) = strb.append(v)
   }
 
   class GenericAttr[T] extends AttrValue[T] {
@@ -155,28 +156,28 @@ object Text
      * because I've inlined a whole lot of things to improve the performance of this code
      * ~4x from what it originally was, which is a pretty nice speedup
      */
-    def writeTo(strb: StringBuilder): Unit = {
+    def writeTo(strb: jStringBuilder): Unit = {
       val builder = new text.Builder()
       build(builder)
 
       // tag
-      strb += '<' ++= tag
+      strb.append('<').append(tag)
 
       // attributes
       var i = 0
       while (i < builder.attrIndex){
         val pair = builder.attrs(i)
-        strb += ' ' ++= pair._1 ++= "=\""
+        strb.append(' ').append(pair._1).append("=\"")
         builder.appendAttrStrings(pair._2,strb)
-        strb += '\"'
+        strb.append('"')
         i += 1
       }
 
       if (builder.childIndex == 0 && void) {
         // No children - close tag
-        strb ++= " />"
+        strb.append(" />")
       } else {
-        strb += '>'
+        strb.append('>')
         // Childrens
         var i = 0
         while(i < builder.childIndex){
@@ -185,7 +186,7 @@ object Text
         }
 
         // Closing tag
-        strb ++= "</" ++= tag += '>'
+        strb.append("</").append(tag).append('>')
       }
     }
 
@@ -197,7 +198,7 @@ object Text
      * Converts an ScalaTag fragment into an html string
      */
     override def toString = {
-      val strb = new StringBuilder
+      val strb = new jStringBuilder
       writeTo(strb)
       strb.toString()
     }

--- a/scalatags/shared/src/main/scala/scalatags/text/Builder.scala
+++ b/scalatags/shared/src/main/scala/scalatags/text/Builder.scala
@@ -1,5 +1,7 @@
 package scalatags
 package text
+import java.lang.{StringBuilder => jStringBuilder}
+
 import acyclic.file
 
 import scala.reflect.ClassTag
@@ -93,12 +95,12 @@ class Builder(var children: Array[Frag] = new Array(4),
   }
 
 
-  def appendAttrStrings(v: Builder.ValueSource, sb: StringBuilder): Unit = {
+  def appendAttrStrings(v: Builder.ValueSource, sb: jStringBuilder): Unit = {
     v.appendAttrValue(sb)
   }
 
   def attrsString(v: Builder.ValueSource): String = {
-    val sb = new StringBuilder
+    val sb = new jStringBuilder
     appendAttrStrings(v, sb)
     sb.toString
   }
@@ -119,34 +121,34 @@ object Builder{
     * string.
     */
   trait ValueSource {
-    def appendAttrValue(strb: StringBuilder): Unit
+    def appendAttrValue(strb: jStringBuilder): Unit
   }
   case class StyleValueSource(s: Style, v: String) extends ValueSource {
-    override def appendAttrValue(strb: StringBuilder): Unit = {
+    override def appendAttrValue(strb: jStringBuilder): Unit = {
       Escaping.escape(s.cssName, strb)
-      strb ++=  ": "
+      strb.append(": ")
       Escaping.escape(v, strb)
-      strb ++= ";"
+      strb.append(';')
     }
   }
 
   case class GenericAttrValueSource(v: String) extends ValueSource {
-    override def appendAttrValue(strb: StringBuilder): Unit = {
+    override def appendAttrValue(strb: jStringBuilder): Unit = {
       Escaping.escape(v, strb)
     }
   }
 
   case class ChainedAttributeValueSource(head: ValueSource, tail: ValueSource) extends ValueSource {
-    override def appendAttrValue(strb: StringBuilder): Unit = {
+    override def appendAttrValue(strb: jStringBuilder): Unit = {
       head.appendAttrValue(strb)
-      strb ++= " "
+      strb.append(' ')
       tail.appendAttrValue(strb)
     }
   }
 }
 
 trait Frag extends generic.Frag[Builder, String]{
-  def writeTo(strb: StringBuilder): Unit
+  def writeTo(strb: jStringBuilder): Unit
   def render: String
   def applyTo(b: Builder) = b.addChild(this)
 }


### PR DESCRIPTION
Prefer native StringBuilder over the scala wrapper.
This allows better hotspot optimization as well as
faster interpreter code.

Fixes #188.