### PR TITLE
More specific Frag type for typed tags

### DIFF
--- a/scalatags/src/scalatags/generic/Core.scala
+++ b/scalatags/src/scalatags/generic/Core.scala
@@ -37,7 +37,7 @@ trait Frag[Builder, +FragT] extends Modifier[Builder]{
  *           `Nothing`, while on ScalaJS this could be the `dom.XXXElement`
  *           associated with that tag name.
  */
-trait TypedTag[Builder, +Output <: FragT, +FragT] extends Frag[Builder, FragT]{
+trait TypedTag[Builder, +Output <: FragT, +FragT] extends Frag[Builder, Output]{
   protected[this] type Self <: TypedTag[Builder, Output, FragT]
   def tag: String
 


### PR DESCRIPTION
I've tried to write an API which would only accept objects which render to standalone `dom.Element`s, yet none of the `JsDom` tags conformed to expected `Frag[dom.Element, dom.Element]` type. This seems to be fixed by the proposed change. Further simplifications may be possible, as `+FragT` in `generic.TypedTag` becomes pretty obsolete then. I didn't push too far though and settled for a more compatible change for now.