### PR TITLE
More specific Frag type for bound nodes

### DIFF
--- a/scalatags/js/src/scalatags/JsDom.scala
+++ b/scalatags/js/src/scalatags/JsDom.scala
@@ -212,7 +212,7 @@ trait LowPriorityImplicits{
       t.asInstanceOf[js.Dynamic].updateDynamic(a.name)(v)
     }
   }
-  implicit class bindNode(e: dom.Node) extends generic.Frag[dom.Element, dom.Node] {
+  implicit class bindNode[T <: dom.Node](e: T) extends generic.Frag[dom.Element, T] {
     def applyTo(t: Element) = t.appendChild(e)
     def render = e
   }


### PR DESCRIPTION
Related to: https://github.com/lihaoyi/scalatags/pull/193

With both of these in place, rendered and unrendered element tags would conform to `Frag[dom.Element, dom.Element]`.