### PR TITLE
Improve AttrPair alias. Make jsdom RawFrag extend Frag

### DIFF
--- a/scalatags/js/src/scalatags/JsDom.scala
+++ b/scalatags/js/src/scalatags/JsDom.scala
@@ -134,10 +134,11 @@ object JsDom
   }
 
   object RawFrag extends Companion[RawFrag]
-  case class RawFrag(v: String) extends Modifier{
+  case class RawFrag(v: String) extends jsdom.Frag{
     Objects.requireNonNull(v)
-    def applyTo(elem: dom.Element): Unit = {
-      elem.insertAdjacentHTML("beforeend", v)
+    def render: dom.Node = {
+      // https://davidwalsh.name/convert-html-stings-dom-nodes
+      dom.document.createRange().createContextualFragment(v)
     }
   }
 

--- a/scalatags/src/scalatags/generic/Bundle.scala
+++ b/scalatags/src/scalatags/generic/Bundle.scala
@@ -90,7 +90,7 @@ trait Aliases[Builder, Output <: FragT, FragT]{
   type SvgTags = generic.SvgTags[Builder, Output, FragT]
   type SvgAttrs = generic.SvgAttrs[Builder, Output, FragT]
   type Util = generic.Util[Builder, Output, FragT]
-  type AttrPair = generic.AttrPair[Builder, FragT]
+  type AttrPair = generic.AttrPair[Builder, _]
 
   type Attr = generic.Attr
   type Style = generic.Style


### PR DESCRIPTION
This PR addresses 2 issues with ScalaJS api.  
They are very small so I didn't separate them... Will do if needed.

## AttrPair alias too restrictive
In Text api, `AttrValue` can only be `String`? as far as I understood.
But in JsDom api it can be almost any type?

Anyways, currently you can't abstract over `AttrPair`s in JsDom api.  
Neither of these compiles:
```scala
import scalatags.JsDom.all._

val a1: AttrPair = required
val a2: AttrPair = tpe := "checkbox"
Seq[AttrPair](required, tpe := "checkbox")
```
See https://scalafiddle.io/sf/f8vAr2s/1

## RawFrag isn't a Frag
This doesn't compile:
```scala
def component(frg: Frag) =
  div(frg)

component(
  raw("")
)
```
Currently it `extends Modifier` and not `Frag`.